### PR TITLE
Get-Secrets.ps1 Updates: Added exceptions and more comments

### DIFF
--- a/Get-Secrets.ps1
+++ b/Get-Secrets.ps1
@@ -13,41 +13,80 @@ if (!(Get-Module -ListAvailable Az.KeyVault)) {
     Install-Module -Name Az.KeyVault -Confirm:$false
 }
 
-# Switch to the AMU Subscription and Tenant
-Write-Host "Setting AzContext to 'TenantName=$TenantName;SubscriptionName=$SubscriptionName'" -ForegroundColor DarkGray
-$Subscription = Set-AzContext -SubscriptionName $SubscriptionName -Tenant (Get-AzTenant | Where-Object Name -match "Andrews McMeel Universal").Id
+# Check if tenant is available
+$Tenant = Get-AzTenant -ErrorAction SilentlyContinue | Where-Object Name -match "$TenantName"
+if (!$Tenant) {
+    Write-Error "Cannot find '$TenantName' tenant. Please try logging in with 'Connect-AzAccount'"
+    return
+}
 
+# Switch to the correct subscription and tenant
+$Subscription = Set-AzContext -SubscriptionName $SubscriptionName -Tenant $Tenant.Id
+Write-Host "AzContext set to 'TenantName=$TenantName;SubscriptionName=$SubscriptionName'" -ForegroundColor DarkGray
+
+# Clear temporary file
 Clear-Content -Path "${File}.tmp" -ErrorAction SilentlyContinue
 
-# If $KeyVaultName argument isn't set
+# Check if searching for key vaults by repository name or otherwise, if key vault name argument is given
 if (!$PSBoundParameters.ContainsKey('KeyVaultName')) {
     # If $Environment argument isn't set, use default value
     if (!$PSBoundParameters.ContainsKey('Environment')) {
         Write-Host "Environment missing. Defaulting to $Environment." -ForegroundColor DarkGray
     }
 
+    # Search for key vault using tags
     Write-Host "Searching for key vault with tags: 'repository-name=$RepositoryName;environment=$Environment'" -ForegroundColor DarkGray
     $KeyVaultName = (Get-AzKeyVault -Tag @{"environment" = "$Environment" } | Get-AzKeyVault -Tag @{"repository-name" = "$RepositoryName" }).VaultName
+
+    # Check if key vault name is empty
+    if (!$KeyVaultName) {
+        Write-Error "Key vault name cannot be found. Please confirm this repository's key vaults are tagged correctly."
+        return
+    }
 }
 else {
+    # Just output KeyVaultName if passed as an argument
     Write-Host "Searching for key vault named: $KeyVaultName" -ForegroundColor DarkGray
 }
 
-# Get secrets for the key vault
-$Secrets = (Get-AzKeyVaultSecret -VaultName "$KeyVaultName").Name
+# Get key vault object
+$KeyVault = Get-AzKeyVault -Name "$KeyVaultName"
+
+# Check if key vault exists
+if (!$KeyVault) {
+    Write-Error "Invalid value provided for 'KeyVaultName'. Please confirm a Key Vault exists under the name specified. Value provided: $KeyVaultName"
+    return
+}
 Write-Host "Key vault found: $KeyVaultName" -ForegroundColor DarkGray
-Write-Host "Retrieving secrets..." -ForegroundColor DarkGray
+
+# Set secrets list 
+$Secrets = (Get-AzKeyVaultSecret -VaultName "$KeyVaultName").Name
+
+# Create secret hash
+$SecretHash = @()
 
 # Loop through secrets and add them to ${File}.tmp
+Write-Host "Retrieving secrets..." -ForegroundColor DarkGray
 $Secrets | ForEach-Object {
+    # Convert to upper case snake case and remove quotes
     $SecretName = $_.ToUpper().Replace("-", "_").Replace("`"", "")
+
+    # Get secret value and set it to the secret name
     $SecretValue = (Get-AzKeyVaultSecret -VaultName "$KeyVaultName" -Name $_).SecretValue | ConvertFrom-SecureString -AsPlainText
-    $Secret = "$SecretName" + "=" + "$SecretValue"
-    Write-Host "$Secret"
-    Add-Content -Path "${File}.tmp" -Value "$Secret"
+
+    # Add secret to hash
+    $SecretHash += [pscustomobject]@{SecretName = $SecretName; SecretValue = $SecretValue}
+
+    # Add secret to temporary file
+    Add-Content -Path "${File}.tmp" -Value "$SecretName=$SecretValue"
 }
 
+# Output secret variable
+$SecretHash | Format-Table
+
+# Copy the temporary file over the original file
 Copy-Item -Path "${File}.tmp" -Destination "${File}"
 Remove-Item -Path "${File}.tmp"-Force -ErrorAction SilentlyContinue
 
+# Output success
 Write-Host "✨ .env file generated from $KeyVaultName" -ForegroundColor Green


### PR DESCRIPTION

## Description

- Updating `Get-Secrets.ps1` script
    - Added an exception for whenever the key vault cannot be found under the given name
    - Added an exception for whenever the key vaults are not tagged correctly
    - Added more comments
    - Added an exception for whenever the user has not ran `Connect-AzAccount` which also errors out when the AMU tenant is not an available AzContext
    - Secrets now output as a PowerShell table when the script finishes
    - Moved around output lines in the file to group them with their relevant steps

## Related Issues

<!-- List any related Jira issues here -->

- Jira Issue: N/A
